### PR TITLE
arrange topSources list vertically

### DIFF
--- a/static/js/components/TopSources.css
+++ b/static/js/components/TopSources.css
@@ -1,3 +1,4 @@
+
 .stamp {
     transition: transform 0.1s;
     width: 20%;
@@ -10,8 +11,8 @@
   transform: scale(2.0);
 }
 
-.div {
-  display: flex;
+.topSourcesContainer {
+  display: block;
   border-style: solid;
   border-width: 1px;
   border-color: #DDD;
@@ -22,8 +23,11 @@
 }
 
 .ul {
-   display: flex;
-   align-items: center;
-   list-style-type: none;
+  display: block;
+  align-items: center;
+  list-style-type: none;
 }
 
+.topSource {
+  margin: 10px;
+}

--- a/static/js/components/TopSources.jsx
+++ b/static/js/components/TopSources.jsx
@@ -19,7 +19,7 @@ const TopSources = () => {
   ) || defaultPrefs;
 
   return (
-    <div className={styles.div}>
+      <div className={styles.topSourcesContainer}>
       <h2 style={{ display: "inline-block" }}>
         Top Sources
       </h2>
@@ -37,7 +37,7 @@ const TopSources = () => {
       <ul className={styles.ul}>
         {
           sourceViews.map(({ obj_id, views, public_url }) => (
-            <li key={`topSources_${obj_id}_${views}`}>
+            <li key={`topSources_${obj_id}_${views}`} className={styles.topSource}>
               <Link to={`/source/${obj_id}`}>
                 <img className={styles.stamp} src={public_url} alt={obj_id} />
               </Link>


### PR DESCRIPTION
This PR slightly alters the layout of the top sources widget, adding some space between the entries and organizing the list elements vertically. 

<img width="506" alt="Screen Shot 2020-08-05 at 8 57 14 PM" src="https://user-images.githubusercontent.com/2769632/89488993-456eac00-d75e-11ea-9fe0-f022f9b490f1.png">
