### PR TITLE
Make Sphinx autodoc happy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ aplpy==2.0.3
 reproject==0.7.1
 avro-python3==1.10.2
 fastavro==1.2.4
-tqdm>=4.23,<4.62
+tqdm>=4.27,<4.62
 matplotlib==3.4.2
 astroquery==0.4.2
 apispec==4.0.0


### PR DESCRIPTION
The documentation issues were due to the automatic docstring parser not being able to detect proper typing associated with decorated properties. I tried a bunch of stuff with trying to tweak the docs setting but in the end just changing the implementation of the properties themselves was how I got it to be happy. 

Requirements bump for tqdm was an unrelated issue I noticed. I think it was the `ligo` package or something like that, but one of the new dependencies required a higher version of tqdm.