### PR TITLE
Clean up permission testing and error messages

### DIFF
--- a/skyportal/tests/api/test_gcn.py
+++ b/skyportal/tests/api/test_gcn.py
@@ -16,9 +16,7 @@ def test_gcn_GW(super_admin_token, view_only_token):
     assert data['status'] == 'success'
 
     dateobs = "2019-04-25 08:18:05"
-    status, data = api(
-        'GET', f'gcn/event/{dateobs}', data=data, token=super_admin_token
-    )
+    status, data = api('GET', f'gcn/event/{dateobs}', token=super_admin_token)
     assert status == 200
     data = data["data"]
     assert data["dateobs"] == "2019-04-25T08:18:05"
@@ -28,7 +26,6 @@ def test_gcn_GW(super_admin_token, view_only_token):
     status, data = api(
         'GET',
         f'gcn/localization/{dateobs}/name/{skymap}',
-        data=data,
         token=super_admin_token,
     )
 
@@ -40,15 +37,13 @@ def test_gcn_GW(super_admin_token, view_only_token):
     status, data = api(
         'DELETE',
         f'gcn/localization/{dateobs}/name/{skymap}',
-        data=data,
         token=view_only_token,
     )
-    assert status == 413
+    assert status == 400
 
     status, data = api(
         'DELETE',
         f'gcn/localization/{dateobs}/name/{skymap}',
-        data=data,
         token=super_admin_token,
     )
     assert status == 200
@@ -66,9 +61,7 @@ def test_gcn_Fermi(super_admin_token, view_only_token):
     assert data['status'] == 'success'
 
     dateobs = "2018-01-16 00:36:53"
-    status, data = api(
-        'GET', f'gcn/event/{dateobs}', data=data, token=super_admin_token
-    )
+    status, data = api('GET', f'gcn/event/{dateobs}', token=super_admin_token)
     assert status == 200
     data = data["data"]
     assert data["dateobs"] == "2018-01-16T00:36:53"
@@ -78,7 +71,6 @@ def test_gcn_Fermi(super_admin_token, view_only_token):
     status, data = api(
         'GET',
         f'gcn/localization/{dateobs}/name/{skymap}',
-        data=data,
         token=super_admin_token,
     )
 
@@ -90,15 +82,13 @@ def test_gcn_Fermi(super_admin_token, view_only_token):
     status, data = api(
         'DELETE',
         f'gcn/localization/{dateobs}/name/{skymap}',
-        data=data,
         token=view_only_token,
     )
-    assert status == 413
+    assert status == 400
 
     status, data = api(
         'DELETE',
         f'gcn/localization/{dateobs}/name/{skymap}',
-        data=data,
         token=super_admin_token,
     )
     assert status == 200


### PR DESCRIPTION
What's happening here:
- Added some `if not _.is_accessible_by()` blocks so we can send back clearer error messages in cases of insufficient permissions. The insufficient permissions are already caught by the `self.verify_and_commit()` calls btw but that was intended as a catch-all safety net type of thing and we try to more explicitly check like this in the handler code so we don't send back the generic "Insufficient permissions" error messages and so on. 
- In a similar vein, converted some `.query()` calls to `.query_records_accessible_by()` calls to do that sort of explicit permission checking and bring it in-line with the style of other SkyPortal handlers. Again, doesn't really change functionality here because it was all for `read=public` records, but it's more for respecting the convention we've established and future-proofing in case it ever becomes non-public.
- Added some logic in the GET calls to send back a 404 if the expected/requested record was not found.
- Tweaked the API calls in your tests so you don't send over the big GCN data objects for GET/DELETE calls as that's not actually necessary for those requests. This is actually why you were seeing 413 errors (data too big) instead of 400 as would be expected if the error was a permission issue.